### PR TITLE
feat(editor): add placeable item settings

### DIFF
--- a/Intersect (Core)/GameObjects/ItemBase.cs
+++ b/Intersect (Core)/GameObjects/ItemBase.cs
@@ -106,6 +106,28 @@ namespace Intersect.GameObjects
         /// </summary>
         public bool CanBag { get; set; } = true;
 
+        /// <summary>
+        /// Defines whether this item can be placed on the map by a player.
+        /// </summary>
+        public bool Placeable { get; set; }
+
+        /// <summary>
+        /// The sprite displayed when this item is placed on the map.
+        /// </summary>
+        public string PlacedSprite { get; set; } = "";
+
+        [Column("PlacedAnimation")]
+        [JsonProperty]
+        public Guid PlacedAnimationId { get; set; }
+
+        [NotMapped]
+        [JsonIgnore]
+        public AnimationBase? PlacedAnimation
+        {
+            get => AnimationBase.Get(PlacedAnimationId);
+            set => PlacedAnimationId = value?.Id ?? Guid.Empty;
+        }
+
         public int CritChance { get; set; }
 
         public double CritMultiplier { get; set; } = 1.5;
@@ -491,6 +513,9 @@ namespace Intersect.GameObjects
             Consumable = new ConsumableData();
             Effects = new List<EffectData>();
             Color = new Color(255, 255, 255, 255);
+            Placeable = false;
+            PlacedSprite = "";
+            PlacedAnimationId = Guid.Empty;
         }
     }
 

--- a/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
@@ -62,6 +62,11 @@ namespace Intersect.Editor.Forms.Editors
             nudItemDespawnTime = new DarkNumericUpDown();
             lblDespawnTime = new Label();
             cmbEquipmentAnimation = new DarkComboBox();
+            chkPlaceable = new DarkCheckBox();
+            lblPlacedSprite = new Label();
+            cmbPlacedSprite = new DarkComboBox();
+            lblPlacedAnimation = new Label();
+            cmbPlacedAnimation = new DarkComboBox();
             grpRequirements = new DarkGroupBox();
             lblCannotUse = new Label();
             txtCannotUse = new DarkTextBox();
@@ -390,6 +395,11 @@ namespace Intersect.Editor.Forms.Editors
             grpGeneral.Controls.Add(nudItemDespawnTime);
             grpGeneral.Controls.Add(lblDespawnTime);
             grpGeneral.Controls.Add(cmbEquipmentAnimation);
+            grpGeneral.Controls.Add(cmbPlacedAnimation);
+            grpGeneral.Controls.Add(lblPlacedAnimation);
+            grpGeneral.Controls.Add(cmbPlacedSprite);
+            grpGeneral.Controls.Add(lblPlacedSprite);
+            grpGeneral.Controls.Add(chkPlaceable);
             grpGeneral.Controls.Add(grpRequirements);
             grpGeneral.Controls.Add(chkCanGuildBank);
             grpGeneral.Controls.Add(lblEquipmentAnimation);
@@ -733,9 +743,86 @@ namespace Intersect.Editor.Forms.Editors
             cmbEquipmentAnimation.Text = "None";
             cmbEquipmentAnimation.TextPadding = new Padding(2);
             cmbEquipmentAnimation.SelectedIndexChanged += cmbEquipmentAnimation_SelectedIndexChanged;
-            // 
+            //
+            // chkPlaceable
+            //
+            chkPlaceable.AutoSize = true;
+            chkPlaceable.Location = new System.Drawing.Point(27, 530);
+            chkPlaceable.Margin = new Padding(4, 3, 4, 3);
+            chkPlaceable.Name = "chkPlaceable";
+            chkPlaceable.Size = new Size(79, 19);
+            chkPlaceable.TabIndex = 103;
+            chkPlaceable.Text = "Placeable";
+            chkPlaceable.CheckedChanged += chkPlaceable_CheckedChanged;
+            //
+            // lblPlacedSprite
+            //
+            lblPlacedSprite.AutoSize = true;
+            lblPlacedSprite.Location = new System.Drawing.Point(9, 558);
+            lblPlacedSprite.Margin = new Padding(4, 0, 4, 0);
+            lblPlacedSprite.Name = "lblPlacedSprite";
+            lblPlacedSprite.Size = new Size(82, 15);
+            lblPlacedSprite.TabIndex = 104;
+            lblPlacedSprite.Text = "Placed Sprite:";
+            //
+            // cmbPlacedSprite
+            //
+            cmbPlacedSprite.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbPlacedSprite.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbPlacedSprite.BorderStyle = ButtonBorderStyle.Solid;
+            cmbPlacedSprite.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbPlacedSprite.DrawDropdownHoverOutline = false;
+            cmbPlacedSprite.DrawFocusRectangle = false;
+            cmbPlacedSprite.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbPlacedSprite.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbPlacedSprite.FlatStyle = FlatStyle.Flat;
+            cmbPlacedSprite.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbPlacedSprite.FormattingEnabled = true;
+            cmbPlacedSprite.Items.AddRange(new object[] { "None" });
+            cmbPlacedSprite.Location = new System.Drawing.Point(175, 553);
+            cmbPlacedSprite.Margin = new Padding(4, 3, 4, 3);
+            cmbPlacedSprite.Name = "cmbPlacedSprite";
+            cmbPlacedSprite.Size = new Size(271, 24);
+            cmbPlacedSprite.TabIndex = 105;
+            cmbPlacedSprite.Text = "None";
+            cmbPlacedSprite.TextPadding = new Padding(2);
+            cmbPlacedSprite.SelectedIndexChanged += cmbPlacedSprite_SelectedIndexChanged;
+            //
+            // lblPlacedAnimation
+            //
+            lblPlacedAnimation.AutoSize = true;
+            lblPlacedAnimation.Location = new System.Drawing.Point(9, 587);
+            lblPlacedAnimation.Margin = new Padding(4, 0, 4, 0);
+            lblPlacedAnimation.Name = "lblPlacedAnimation";
+            lblPlacedAnimation.Size = new Size(101, 15);
+            lblPlacedAnimation.TabIndex = 106;
+            lblPlacedAnimation.Text = "Placed Animation:";
+            //
+            // cmbPlacedAnimation
+            //
+            cmbPlacedAnimation.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbPlacedAnimation.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbPlacedAnimation.BorderStyle = ButtonBorderStyle.Solid;
+            cmbPlacedAnimation.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbPlacedAnimation.DrawDropdownHoverOutline = false;
+            cmbPlacedAnimation.DrawFocusRectangle = false;
+            cmbPlacedAnimation.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbPlacedAnimation.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbPlacedAnimation.FlatStyle = FlatStyle.Flat;
+            cmbPlacedAnimation.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbPlacedAnimation.FormattingEnabled = true;
+            cmbPlacedAnimation.Items.AddRange(new object[] { "None" });
+            cmbPlacedAnimation.Location = new System.Drawing.Point(175, 582);
+            cmbPlacedAnimation.Margin = new Padding(4, 3, 4, 3);
+            cmbPlacedAnimation.Name = "cmbPlacedAnimation";
+            cmbPlacedAnimation.Size = new Size(271, 24);
+            cmbPlacedAnimation.TabIndex = 107;
+            cmbPlacedAnimation.Text = "None";
+            cmbPlacedAnimation.TextPadding = new Padding(2);
+            cmbPlacedAnimation.SelectedIndexChanged += cmbPlacedAnimation_SelectedIndexChanged;
+            //
             // grpRequirements
-            // 
+            //
             grpRequirements.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
             grpRequirements.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
             grpRequirements.Controls.Add(lblCannotUse);
@@ -3250,6 +3337,11 @@ namespace Intersect.Editor.Forms.Editors
         private DarkComboBox cmbWeaponSprite;
         private DarkNumericUpDown nudItemDespawnTime;
         private Label lblDespawnTime;
+        private DarkCheckBox chkPlaceable;
+        private Label lblPlacedSprite;
+        private DarkComboBox cmbPlacedSprite;
+        private Label lblPlacedAnimation;
+        private DarkComboBox cmbPlacedAnimation;
         private ToolTip tooltips;
         private DarkGroupBox grpEffects;
         private ListBox lstBonusEffects;

--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -139,6 +139,14 @@ namespace Intersect.Editor.Forms.Editors
             cmbEquipmentAnimation.Items.Clear();
             cmbEquipmentAnimation.Items.Add(Strings.General.None);
             cmbEquipmentAnimation.Items.AddRange(AnimationBase.Names);
+            cmbPlacedAnimation.Items.Clear();
+            cmbPlacedAnimation.Items.Add(Strings.General.None);
+            cmbPlacedAnimation.Items.AddRange(AnimationBase.Names);
+            cmbPlacedSprite.Items.Clear();
+            cmbPlacedSprite.Items.Add(Strings.General.None);
+            cmbPlacedSprite.Items.AddRange(
+                GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Resource)
+            );
             cmbTeachSpell.Items.Clear();
             cmbTeachSpell.Items.Add(Strings.General.None);
             cmbTeachSpell.Items.AddRange(SpellBase.Names);
@@ -218,6 +226,9 @@ namespace Intersect.Editor.Forms.Editors
             chkCanBag.Text = Strings.ItemEditor.CanBag;
             chkCanTrade.Text = Strings.ItemEditor.CanTrade;
             chkCanSell.Text = Strings.ItemEditor.CanSell;
+            chkPlaceable.Text = Strings.ItemEditor.Placeable;
+            lblPlacedSprite.Text = Strings.ItemEditor.PlacedSprite;
+            lblPlacedAnimation.Text = Strings.ItemEditor.PlacedAnimation;
 
             grpStack.Text = Strings.ItemEditor.StackOptions;
             chkStackable.Text = Strings.ItemEditor.stackable;
@@ -389,6 +400,12 @@ namespace Intersect.Editor.Forms.Editors
                 chkCanBag.Checked = Convert.ToBoolean(mEditorItem.CanBag);
                 chkCanSell.Checked = Convert.ToBoolean(mEditorItem.CanSell);
                 chkCanTrade.Checked = Convert.ToBoolean(mEditorItem.CanTrade);
+                chkPlaceable.Checked = mEditorItem.Placeable;
+                cmbPlacedSprite.SelectedIndex = cmbPlacedSprite.FindString(
+                    TextUtils.NullToNone(mEditorItem.PlacedSprite)
+                );
+                cmbPlacedAnimation.SelectedIndex =
+                    AnimationBase.ListIndex(mEditorItem.PlacedAnimationId) + 1;
                 chkStackable.Checked = Convert.ToBoolean(mEditorItem.Stackable);
                 nudInvStackLimit.Value = mEditorItem.MaxInventoryStack;
                 nudBankStackLimit.Value = mEditorItem.MaxBankStack;
@@ -403,6 +420,7 @@ namespace Intersect.Editor.Forms.Editors
                 nudBlockAmount.Value = mEditorItem.BlockAmount;
                 nudBlockDmgAbs.Value = mEditorItem.BlockAbsorption;
                 RefreshExtendedData();
+                UpdatePlaceableControls();
 
                 chk2Hand.Checked = mEditorItem.TwoHanded;
                 cmbMalePaperdoll.SelectedIndex =
@@ -750,6 +768,15 @@ namespace Intersect.Editor.Forms.Editors
             }
         }
 
+        private void UpdatePlaceableControls()
+        {
+            var enabled = chkPlaceable.Checked;
+            lblPlacedSprite.Enabled = enabled;
+            cmbPlacedSprite.Enabled = enabled;
+            lblPlacedAnimation.Enabled = enabled;
+            cmbPlacedAnimation.Enabled = enabled;
+        }
+
         private void UpdateToolStripItems()
         {
             toolStripItemCopy.Enabled = mEditorItem != null && lstGameObjects.Focused;
@@ -793,6 +820,23 @@ namespace Intersect.Editor.Forms.Editors
         private void cmbProjectile_SelectedIndexChanged(object sender, EventArgs e)
         {
             mEditorItem.Projectile = ProjectileBase.Get(ProjectileBase.IdFromList(cmbProjectile.SelectedIndex - 1));
+        }
+
+        private void cmbPlacedSprite_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            mEditorItem.PlacedSprite = TextUtils.SanitizeNone(cmbPlacedSprite.Text);
+        }
+
+        private void cmbPlacedAnimation_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            mEditorItem.PlacedAnimation =
+                AnimationBase.Get(AnimationBase.IdFromList(cmbPlacedAnimation.SelectedIndex - 1));
+        }
+
+        private void chkPlaceable_CheckedChanged(object sender, EventArgs e)
+        {
+            mEditorItem.Placeable = chkPlaceable.Checked;
+            UpdatePlaceableControls();
         }
 
         private void btnEditRequirements_Click(object sender, EventArgs e)

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -3676,6 +3676,15 @@ Tick timer saved in server config.json.";
             public static LocalizedString CanBag = @"Can Bag?";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString Placeable = @"Placeable";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString PlacedSprite = @"Placed Sprite:";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public static LocalizedString PlacedAnimation = @"Placed Animation:";
+
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public static LocalizedString CanBank = @"Can Bank?";
 
             [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]


### PR DESCRIPTION
## Summary
- allow items to be marked as placeable and configure sprite/animation
- persist new placeable properties on ItemBase
- localize new item editor controls

## Testing
- `dotnet test` *(fails: project files not found)*
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a64401ecbc8320b76587e3ba3e36ca