### PR TITLE
feat: implement placeable items with persistence

### DIFF
--- a/Intersect (Core)/GameObjects/ItemBase.cs
+++ b/Intersect (Core)/GameObjects/ItemBase.cs
@@ -184,6 +184,21 @@ namespace Intersect.GameObjects
 
         public string Icon { get; set; } = "";
 
+        public bool Placeable { get; set; }
+
+        public string PlacedSprite { get; set; } = "";
+
+        [Column("PlacedAnimation")]
+        public Guid PlacedAnimationId { get; set; }
+
+        [NotMapped]
+        [JsonIgnore]
+        public AnimationBase PlacedAnimation
+        {
+            get => AnimationBase.Get(PlacedAnimationId);
+            set => PlacedAnimationId = value?.Id ?? Guid.Empty;
+        }
+
         /// <summary>
         /// The database compatible version of <see cref="Color"/>
         /// </summary>

--- a/Intersect (Core)/GameObjects/Maps/MapBase.cs
+++ b/Intersect (Core)/GameObjects/Maps/MapBase.cs
@@ -277,6 +277,24 @@ namespace Intersect.GameObjects.Maps
         [JsonProperty]
         public List<NpcSpawn> Spawns { get; private set; } = new List<NpcSpawn>();
 
+        [Column("PlacedItems")]
+        [JsonIgnore]
+        public string PlacedItemsJson
+        {
+            get => JsonConvert.SerializeObject(PlacedItems);
+            set
+            {
+                PlacedItems.Clear();
+                var items = JsonConvert.DeserializeObject<List<PlacedMapItem>>(value ?? string.Empty);
+                if (items != null)
+                {
+                    PlacedItems.AddRange(items);
+                }
+            }
+        }
+
+        public List<PlacedMapItem> PlacedItems { get; private set; } = new List<PlacedMapItem>();
+
         //Properties
         public string Music { get; set; } = null;
 

--- a/Intersect (Core)/GameObjects/Maps/PlacedMapItem.cs
+++ b/Intersect (Core)/GameObjects/Maps/PlacedMapItem.cs
@@ -1,0 +1,15 @@
+using System;
+using Intersect.Network.Packets.Server;
+
+namespace Intersect.GameObjects.Maps
+{
+    public class PlacedMapItem
+    {
+        public Guid ItemId { get; set; }
+        public Guid? BagId { get; set; }
+        public int Quantity { get; set; }
+        public int X { get; set; }
+        public int Y { get; set; }
+        public ItemProperties Properties { get; set; } = new ItemProperties();
+    }
+}

--- a/Intersect (Core)/Network/Packets/Client/PlaceItemPacket.cs
+++ b/Intersect (Core)/Network/Packets/Client/PlaceItemPacket.cs
@@ -1,0 +1,20 @@
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public class PlaceItemPacket : IntersectPacket
+{
+    //Parameterless Constructor for MessagePack
+    public PlaceItemPacket()
+    {
+    }
+
+    public PlaceItemPacket(int slot)
+    {
+        Slot = slot;
+    }
+
+    [Key(0)]
+    public int Slot { get; set; }
+}

--- a/Intersect (Core)/Network/Packets/Server/MapItemUpdatePacket.cs
+++ b/Intersect (Core)/Network/Packets/Server/MapItemUpdatePacket.cs
@@ -20,7 +20,7 @@ namespace Intersect.Network.Packets.Server
         }
 
         //Item data implies item added or updated
-        public MapItemUpdatePacket(Guid mapId, int tileIndex, Guid uniqueId, Guid itemId, Guid? bagId, int quantity, ItemProperties properties)
+        public MapItemUpdatePacket(Guid mapId, int tileIndex, Guid uniqueId, Guid itemId, Guid? bagId, int quantity, ItemProperties properties, bool placed)
         {
             MapId = mapId;
             TileIndex = tileIndex;
@@ -29,6 +29,7 @@ namespace Intersect.Network.Packets.Server
             BagId = bagId;
             Quantity = quantity;
             Properties = properties;
+            Placed = placed;
         }
 
         [Key(0)]
@@ -51,6 +52,9 @@ namespace Intersect.Network.Packets.Server
 
         [Key(6)]
         public ItemProperties Properties { get; set; }
+
+        [Key(7)]
+        public bool Placed { get; set; }
 
     }
 

--- a/Intersect.Client.Framework/Entities/IPlayer.cs
+++ b/Intersect.Client.Framework/Entities/IPlayer.cs
@@ -44,6 +44,7 @@ namespace Intersect.Client.Framework.Entities
         long GetItemRemainingCooldown(int slot);
         bool IsItemOnCooldown(int slot);
         void TryDropItem(int index);
+        void TryPlaceItem(int index);
         void TryUseItem(int index);
         void SwapSpells(int spell1, int spell2);
         long GetSpellCooldown(Guid id);

--- a/Intersect.Client.Framework/Items/IMapItemInstance.cs
+++ b/Intersect.Client.Framework/Items/IMapItemInstance.cs
@@ -8,5 +8,6 @@ namespace Intersect.Client.Framework.Items
         Guid Id { get; set; }
         int X { get; set; }
         int Y { get; set; }
+        bool Placed { get; set; }
     }
 }

--- a/Intersect.Client/Entities/Player.cs
+++ b/Intersect.Client/Entities/Player.cs
@@ -403,6 +403,22 @@ namespace Intersect.Client.Entities
             );
         }
 
+        public void TryPlaceItem(int inventorySlotIndex)
+        {
+            var inventorySlot = Inventory[inventorySlotIndex];
+            if (!ItemBase.TryGet(inventorySlot.ItemId, out var itemDescriptor))
+            {
+                return;
+            }
+
+            if (!itemDescriptor.Placeable)
+            {
+                return;
+            }
+
+            PacketSender.SendPlaceItem(inventorySlotIndex);
+        }
+
         private void DropInputBoxOkay(object sender, EventArgs e)
         {
             var value = (int)Math.Round(((InputBox)sender).Value);

--- a/Intersect.Client/Interface/Game/Inventory/InventoryItem.cs
+++ b/Intersect.Client/Interface/Game/Inventory/InventoryItem.cs
@@ -159,7 +159,15 @@ namespace Intersect.Client.Interface.Game.Inventory
                 }
                 else
                 {
-                    Globals.Me.TryDropItem(mMySlot);
+                    var slot = Globals.Me.Inventory[mMySlot];
+                    if (ItemBase.TryGet(slot.ItemId, out var descriptor) && descriptor.Placeable)
+                    {
+                        Globals.Me.TryPlaceItem(mMySlot);
+                    }
+                    else
+                    {
+                        Globals.Me.TryDropItem(mMySlot);
+                    }
                 }
             }
         }

--- a/Intersect.Client/Interface/Game/MapItem/MapItemIcon.cs
+++ b/Intersect.Client/Interface/Game/MapItem/MapItemIcon.cs
@@ -114,7 +114,15 @@ namespace Intersect.Client.Interface.Game.Inventory
             var item = ItemBase.Get(MyItem.ItemId);
             if (item != null)
             {
-                var itemTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, item.Icon);
+                var textureName = item.Icon;
+                var textureType = Framework.Content.TextureType.Item;
+                if (MyItem.Placed && item.Placeable && !string.IsNullOrEmpty(item.PlacedSprite))
+                {
+                    textureName = item.PlacedSprite;
+                    textureType = Framework.Content.TextureType.Item;
+                }
+
+                var itemTex = Globals.ContentManager.GetTexture(textureType, textureName);
                 if (itemTex != null)
                 {
                     Pnl.RenderColor = item.Color;

--- a/Intersect.Client/Items/MapItemInstance.cs
+++ b/Intersect.Client/Items/MapItemInstance.cs
@@ -20,11 +20,13 @@ namespace Intersect.Client.Items
 
         [JsonIgnore] public int TileIndex => Y * Options.MapWidth + X;
 
+        public bool Placed { get; set; }
+
         public MapItemInstance() : base()
         {
         }
 
-        public MapItemInstance(int tileIndex, Guid uniqueId, Guid itemId, Guid? bagId, int quantity, ItemProperties itemProperties) : base()
+        public MapItemInstance(int tileIndex, Guid uniqueId, Guid itemId, Guid? bagId, int quantity, ItemProperties itemProperties, bool placed) : base()
         {
             Id = uniqueId;
             X = tileIndex % Options.MapWidth;
@@ -33,6 +35,7 @@ namespace Intersect.Client.Items
             BagId = bagId;
             Quantity = quantity;
             ItemProperties = itemProperties;
+            Placed = placed;
         }
 
     }

--- a/Intersect.Client/Networking/PacketHandler.cs
+++ b/Intersect.Client/Networking/PacketHandler.cs
@@ -1215,7 +1215,7 @@ namespace Intersect.Client.Networking
             map.MapItems.Clear();
             foreach(var item in packet.Items)
             {
-                var mapItem = new MapItemInstance(item.TileIndex,item.Id, item.ItemId, item.BagId, item.Quantity, item.Properties);
+                var mapItem = new MapItemInstance(item.TileIndex,item.Id, item.ItemId, item.BagId, item.Quantity, item.Properties, item.Placed);
                 
                 if (!map.MapItems.ContainsKey(mapItem.TileIndex))
                 {
@@ -1256,7 +1256,7 @@ namespace Intersect.Client.Networking
                 }
 
                 // Check if the item already exists, if it does replace it. Otherwise just add it.
-                var mapItem = new MapItemInstance(packet.TileIndex, packet.Id, packet.ItemId, packet.BagId, packet.Quantity, packet.Properties);
+                var mapItem = new MapItemInstance(packet.TileIndex, packet.Id, packet.ItemId, packet.BagId, packet.Quantity, packet.Properties, packet.Placed);
                 if (map.MapItems[packet.TileIndex].Any(item => item.Id == mapItem.Id))
                 {
                     for (var index = 0; index < map.MapItems[packet.TileIndex].Count; index++)

--- a/Intersect.Client/Networking/PacketSender.cs
+++ b/Intersect.Client/Networking/PacketSender.cs
@@ -189,6 +189,11 @@ namespace Intersect.Client.Networking
             Network.SendPacket(new DropItemPacket(slot, amount));
         }
 
+        public static void SendPlaceItem(int slot)
+        {
+            Network.SendPacket(new PlaceItemPacket(slot));
+        }
+
         public static void SendUseItem(int slot, Guid targetId)
         {
             Network.SendPacket(new UseItemPacket(slot, targetId));

--- a/Intersect.Server.Core/Database/DbInterface.cs
+++ b/Intersect.Server.Core/Database/DbInterface.cs
@@ -1374,8 +1374,11 @@ namespace Intersect.Server.Database
 
                             break;
                         case GameObjectType.Map:
-                            context.Maps.Update((MapController)gameObject);
-
+                            if (gameObject is MapController mapController)
+                            {
+                                mapController.CapturePlacedItems();
+                                context.Maps.Update(mapController);
+                            }
                             break;
                         case GameObjectType.Event:
                             context.Events.Update((EventBase)gameObject);

--- a/Intersect.Server.Core/Maps/MapController.cs
+++ b/Intersect.Server.Core/Maps/MapController.cs
@@ -391,6 +391,33 @@ namespace Intersect.Server.Maps
             DbInterface.SaveGameObject(this);
         }
 
+        public void CapturePlacedItems()
+        {
+            if (!mInstances.TryGetValue(MapInstance.OverworldInstanceId, out var mapInstance))
+            {
+                return;
+            }
+
+            PlacedItems.Clear();
+            foreach (var item in mapInstance.AllMapItems.Values)
+            {
+                if (!item.Placed)
+                {
+                    continue;
+                }
+
+                PlacedItems.Add(new PlacedMapItem
+                {
+                    ItemId = item.ItemId,
+                    BagId = item.BagId,
+                    Quantity = item.Quantity,
+                    X = item.X,
+                    Y = item.Y,
+                    Properties = new ItemProperties(item.Properties)
+                });
+            }
+        }
+
         #region Map Instance Management
         /// <summary>
         /// Despawns all entities/items/projectiles on each instance that belongs to this controller

--- a/Intersect.Server.Core/Maps/MapInstance.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.cs
@@ -240,6 +240,7 @@ namespace Intersect.Server.Maps
             SpawnMapNpcs();
             SpawnAttributeItems(); // This must be done before spawning items or resources
             SpawnMapResources();
+            SpawnPlacedItems();
             RefreshEventsCache();
             SpawnGlobalEvents();
         }
@@ -955,6 +956,34 @@ namespace Intersect.Server.Maps
                     }
                 }
             }
+        }
+
+        private void SpawnPlacedItems()
+        {
+            foreach (var placed in mMapController.PlacedItems)
+            {
+                var mapItem = new MapItem(placed.ItemId, placed.Quantity, placed.X, placed.Y, placed.BagId, null)
+                {
+                    Placed = true,
+                    VisibleToAll = true,
+                    DespawnTime = -1,
+                };
+                mapItem.Properties = new ItemProperties(placed.Properties);
+                AddItem(mapItem);
+            }
+        }
+
+        public void PlaceItem(int x, int y, Item item)
+        {
+            var mapItem = new MapItem(item.ItemId, item.Quantity, x, y, item.BagId, item.Bag)
+            {
+                Placed = true,
+                VisibleToAll = true,
+                DespawnTime = -1,
+            };
+            mapItem.SetupStatBuffs(item);
+            AddItem(mapItem);
+            PacketSender.SendMapItemUpdate(mMapController.Id, MapInstanceId, mapItem, false);
         }
         #endregion
 

--- a/Intersect.Server.Core/Maps/MapItemInstance.cs
+++ b/Intersect.Server.Core/Maps/MapItemInstance.cs
@@ -37,6 +37,8 @@ namespace Intersect.Server.Maps
         // We need this mostly for the client-side.. They can't keep track of our timer after all!
         public bool VisibleToAll = true;
 
+        public bool Placed { get; set; }
+
         public MapItem(Guid itemId, int quantity, int x, int y, long respawnTime = 0) : base(itemId, quantity)
         {
             UniqueId = Guid.NewGuid();

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -1712,6 +1712,18 @@ namespace Intersect.Server.Networking
             player?.DropItemFrom(packet.Slot, packet.Quantity);
         }
 
+        //PlaceItemPacket
+        public void HandlePacket(Client client, PlaceItemPacket packet)
+        {
+            var player = client?.Entity;
+            if (packet == null)
+            {
+                return;
+            }
+
+            player?.TryPlaceItemFrom(packet.Slot);
+        }
+
         //UseItemPacket
         public void HandlePacket(Client client, UseItemPacket packet)
         {

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1094,7 +1094,7 @@ namespace Intersect.Server.Networking
                 {
                     if (item.VisibleToAll || item.Owner == player?.Id)
                     {
-                        items.Add(new MapItemUpdatePacket(mapId, item.TileIndex, item.UniqueId, item.ItemId, item.BagId, item.Quantity, item.Properties));
+                        items.Add(new MapItemUpdatePacket(mapId, item.TileIndex, item.UniqueId, item.ItemId, item.BagId, item.Quantity, item.Properties, item.Placed));
                     }
                 }
             }
@@ -1160,12 +1160,12 @@ namespace Intersect.Server.Networking
                     var player = Player.FindOnline(itemRef.Owner);
                     if (player != null)
                     {
-                        player.SendPacket(new MapItemUpdatePacket(mapId, itemRef.TileIndex, itemRef.UniqueId, itemRef.ItemId, itemRef.BagId, itemRef.Quantity, itemRef.Properties));
+                        player.SendPacket(new MapItemUpdatePacket(mapId, itemRef.TileIndex, itemRef.UniqueId, itemRef.ItemId, itemRef.BagId, itemRef.Quantity, itemRef.Properties, itemRef.Placed));
                     }
                 }
                 else
                 {
-                    SendDataToProximityOnMapInstance(mapId, mapInstanceId, new MapItemUpdatePacket(mapId, itemRef.TileIndex, itemRef.UniqueId, itemRef.ItemId, itemRef.BagId, itemRef.Quantity, itemRef.Properties));
+                    SendDataToProximityOnMapInstance(mapId, mapInstanceId, new MapItemUpdatePacket(mapId, itemRef.TileIndex, itemRef.UniqueId, itemRef.ItemId, itemRef.BagId, itemRef.Quantity, itemRef.Properties, itemRef.Placed));
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add placeable flags and visuals to item definitions
- allow maps to persist placed items
- enable placing items via new packet and server/client handling

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a27d2b75a4832098d48bc8b5044e11